### PR TITLE
Add keywords and categories to Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ documentation = "https://docs.rs/threadpool"
 description = """
 A thread pool for running a number of jobs on a fixed set of worker threads.
 """
-categories = ["concurrency"]
+keywords = ["threadpool", "thread", "pool", "threading", "parallelism"]
+categories = ["concurrency", "os"]
 
 [dependencies]
 num_cpus = "1.6"


### PR DESCRIPTION
 - Add a set of keywords that I'd search for when looking for a similar
   library.
 - Add the 'os' category - there seem to be other libraries in that
   category that offer similar abstractions on top of OS level features
   like threads.
 - Considered (but didn't) add the 'asynchronous' category. The
   crates.io description for that category suggest it's exclusively for
   Tokio-like libraries.

Fixes #84.

