### PR TITLE
Join waves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+
+# Add tempfiles so cargo watch does not trigger before save
+*.kate-swp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1266,7 +1266,7 @@ mod test {
             p_clock.execute(move || {
                 barrier.wait();
                 // this sleep is for stabilisation on weaker platforms
-                sleep(Duration::from_millis(10));
+                sleep(Duration::from_millis(100));
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,6 +584,9 @@ impl ThreadPool {
     ///
     /// Calling `join` on an empty pool will cause an immediate return.
     /// `join` may be called from multiple threads concurrently.
+    /// A `join` is an atomic point in time. All threads joining before the join
+    /// event will exit together even if the pool is processing new jobs by the
+    /// time they get scheduled.
     ///
     /// Calling `join` from a thread within the pool will cause a deadlock. This
     /// behavior is considered safe.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,11 +619,12 @@ impl ThreadPool {
         let generation = self.shared_data.join_generation.load(Ordering::SeqCst);
         let mut lock = self.shared_data.empty_trigger.lock().unwrap();
 
-        while generation == self.shared_data.join_generation.load(Ordering::Relaxed) &&
-                self.shared_data.has_work() {
+        while generation == self.shared_data.join_generation.load(Ordering::Relaxed)
+                && self.shared_data.has_work() {
             lock = self.shared_data.empty_condvar.wait(lock).unwrap();
         }
 
+        // increase generation if we are the first thread to come out of the loop
         self.shared_data.join_generation.compare_and_swap(generation, generation.wrapping_add(1), Ordering::SeqCst);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,11 +607,13 @@ impl ThreadPool {
     /// assert_eq!(42, test_count.load(Ordering::Relaxed));
     /// ```
     pub fn join(&self) {
+        if self.shared_data.has_work() == false {
+            return ();
+        }
+
+        let mut lock = self.shared_data.empty_trigger.lock().unwrap();
         while self.shared_data.has_work() {
-            let mut lock = self.shared_data.empty_trigger.lock().unwrap();
-            while self.shared_data.has_work() {
-                lock = self.shared_data.empty_condvar.wait(lock).unwrap();
-            }
+            lock = self.shared_data.empty_condvar.wait(lock).unwrap();
         }
     }
 }


### PR DESCRIPTION
When I talked about the threadpool at the Zürichsee meetup somebody came up with a problem when multiple threads join on a pool.

The scenario is joining threads should not be stuck once their wave
of joins has completed. So once one thread joining on a pool has
succeded other threads joining on the same pool must get out even if
the thread is used for other jobs while the first group is finishing
their join
