### PR TITLE
Update link to not-unsafe behavior reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! Keep in mind, if a barrier synchronizes more jobs than you have workers in the pool,
 //! you will end up with a [deadlock](https://en.wikipedia.org/wiki/Deadlock)
 //! at the barrier which is [not considered unsafe]
-//! (http://doc.rust-lang.org/reference.html#behavior-not-considered-unsafe).
+//! (https://doc.rust-lang.org/reference/behavior-not-considered-unsafe.html).
 //!
 //! ```
 //! use threadpool::ThreadPool;


### PR DESCRIPTION
The existing link is to the older references pages and redirected users to the TOC for the latest reference pages. This change updates the path to the current url.