### PR TITLE
fix a typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 //!
 //! Keep in mind, if a barrier synchronizes more jobs than you have workers in the pool,
 //! you will end up with a [deadlock](https://en.wikipedia.org/wiki/Deadlock)
-//! at the barrier which is [not considered unsafe]
-//! (https://doc.rust-lang.org/reference/behavior-not-considered-unsafe.html).
+//! at the barrier which is [not considered unsafe](
+//! https://doc.rust-lang.org/reference/behavior-not-considered-unsafe.html).
 //!
 //! ```
 //! use threadpool::ThreadPool;


### PR DESCRIPTION
Fixed a typo in doc that caused the link to display improperly.